### PR TITLE
fix(putasset) fix filename flag on readme and help

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Options:
   -r, --repo      name of repository
   -o, --owner     owner of repository
   -t, --tag       tag of repository (should exist!)
-  -f, --file      path to asset
+  -f, --filename  path to asset
   -k, --token     github token <https://github.com/settings/tokens/new>
   -l, --loud      output filename, repo, owner and tag before upload
   --show-url      show asset url
@@ -79,4 +79,3 @@ MIT
 [BuildStatusURL]:           https://travis-ci.org/coderaiser/node-putasset  "Build Status"
 [DependencyStatusURL]:      https://david-dm.org/coderaiser/node-putasset "Dependency Status"
 [LicenseURL]:               https://tldrlegal.com/license/mit-license "MIT License"
-

--- a/help.json
+++ b/help.json
@@ -4,7 +4,7 @@
     "-r, --repo     ": "name of repository",
     "-o, --owner    ": "owner of repository",
     "-t, --tag      ": "tag of repository (should exist!)",
-    "-f, --file     ": "path to asset",
+    "-f, --filename ": "path to asset",
     "-k, --token    ": "github token <https://github.com/settings/tokens/new>",
     "-l, --loud     ": "output filename, repo, owner and tag before upload",
     "--show-url     ": "show asset url",


### PR DESCRIPTION
Readme and help outputs used to show `--file` flag which caused the error `filename could not be empty!` . They are now fix, and the flag has been replaced with the correct `--filename`,